### PR TITLE
Support : Specifiying Additional capabilities via Appsetting.json

### DIFF
--- a/src/AxaFrance.WebEngine/appsettings.json
+++ b/src/AxaFrance.WebEngine/appsettings.json
@@ -12,8 +12,10 @@
   "BrowserVersion": null,
   "Capabilities": {
     "additionalCapability1": "value1",
-    "additionalCapability2": "value2"
-  },
+    "bstack:option": {
+      "local": "true"
+    }
+   },
   "chromeOptions": [ "incognito" ],
   "firefoxOptions": [],
   "edgeOptions": [ "inprivate", "start-maximized" ],

--- a/src/WebEngine.Test/appsettings.json
+++ b/src/WebEngine.Test/appsettings.json
@@ -13,7 +13,10 @@
   "Capabilities": {
     "additionalCapability1": "value1",
     "bstack:options": {
-      "local": "true"
+      "local": "true",
+      "projectName": "myproject",
+      "buildName": "mybuild 1.0",
+      "sessionName":  "mysession"
     }
   },
   "chromeOptions": [ "incognito" ],

--- a/src/WebEngine.Test/appsettings.json
+++ b/src/WebEngine.Test/appsettings.json
@@ -1,19 +1,23 @@
 {
   "LogDir": null,
-  "GridConnection": "http://localhost:4723/wd/hub",
-  "GridForDesktop": false,
+  "GridConnection": "http://hub.browserstack.com/wd/hub",
+  "GridForDesktop": true,
   "Username": "",
   "Password": "",
-  "PackageUploadTargetUrl": "https://api-cloud.browserstack.com/app-automate/upload",
+  "PackageUploadTargetUrl": "https://yourcloudprovider.com/apploader/upload",
   "AllowInsecureCertificate": false,
   "PackageName": "my.company.myapplication",
   "EncryptionKey": null,
+  "OsVersion": null,
+  "BrowserVersion": null,
   "Capabilities": {
     "additionalCapability1": "value1",
-    "additionalCapability2": "value2"
+    "bstack:options": {
+      "local": "true"
+    }
   },
-  "chromeOptions": [],
+  "chromeOptions": [ "incognito" ],
   "firefoxOptions": [],
-  "edgeOptions": [ "inprivate" ],
+  "edgeOptions": [ "inprivate", "start-maximized" ],
   "safariOptions": []
 }


### PR DESCRIPTION
Evolution on the appsetting.json format: In the capabilities structure, additional capabilities are provided. But so far, it only supports simple values.

The Framework should supports complex values as used by cloud providers such as `browserstack` and `saucelabs`, for example:  `bstack:options` has a json structure instead of a string. This makes it possible to transparently support all suppliers.

Processing rules:

Today: In the framework if we test on browserstack, we create the bstack:options structure with username, accessKey, os, osversion and deviceName etc in the structure and add this capability in driver options.

After evolution:

The processing above remains the same, but before adding in driver options, we merge the bstack:options structure with those specified in appsetting.json. this allows users to specify browserstacks parameters e.g. for local testing, build name, session name etc.