### PR TITLE
feat: [ReportViewer] add filter on test name and failed tests

### DIFF
--- a/src/AxaFrance.WebEngine.ReportViewer/App.xaml.cs
+++ b/src/AxaFrance.WebEngine.ReportViewer/App.xaml.cs
@@ -20,6 +20,9 @@ namespace AxaFrance.WebEngine.ReportViewer
     {
 
         public static string LogFile { get; set; }
+        public static string Filter { get; set; }
+        public static bool FilterFailed { get; set; }
+
         private void Application_Startup(object sender, StartupEventArgs e)
         {
             this.StartupUri = new Uri("MainWindow.xaml", UriKind.RelativeOrAbsolute);

--- a/src/AxaFrance.WebEngine.ReportViewer/MainWindow.xaml
+++ b/src/AxaFrance.WebEngine.ReportViewer/MainWindow.xaml
@@ -136,22 +136,31 @@
         </TabControl>
 
 
-        <ListBox x:Name="lvTestcases" Grid.Row="2" Grid.Column="0" Grid.RowSpan="2" BorderThickness="0,1,0,0" SelectionChanged="lvTestcases_SelectionChanged" Background="Transparent" Margin="0,0,6,0" >
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <Grid Background="Transparent">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Image Source="{Binding Result, Converter={StaticResource ResultToImageSourceConverter}}" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="4,4" />
-                        <TextBlock Text="{Binding TestName}" Grid.Column="1" Margin="4" VerticalAlignment="Center" />
-                        <TextBlock Text="{Binding DurationText}" Grid.Column="2" Margin="4" VerticalAlignment="Center" Foreground="#CCCCCC" />
-                    </Grid>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
+        <StackPanel Orientation="Vertical" VerticalAlignment="Top" Grid.Row="2" Grid.Column="0" Grid.RowSpan="2">
+
+            <StackPanel Orientation="Horizontal"  HorizontalAlignment="Right" VerticalAlignment="Top">
+                <Label Content="Filter" HorizontalAlignment="Left"   />
+                <TextBox x:Name="txFilter" HorizontalAlignment="Left" TextWrapping="Wrap" Text="" Height="25" Width="175" TextChanged="TxFilter_OnTextChanged" />
+                <CheckBox x:Name="cbFailed" Content="Failed"  Foreground="White" Checked="CbFailed_OnChecked" Unchecked="cbFailed_Unchecked"/>
+            </StackPanel>
+            <ListBox x:Name="lvTestcases"  BorderThickness="0,1,0,0" SelectionChanged="lvTestcases_SelectionChanged" Background="Transparent" Margin="0,0,6,0" Height="693" VerticalAlignment="Top" >
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Grid Background="Transparent">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Image Source="{Binding Result, Converter={StaticResource ResultToImageSourceConverter}}" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="4,4" />
+                            <TextBlock Text="{Binding TestName}" Grid.Column="1" Margin="4" VerticalAlignment="Center" />
+                            <TextBlock Text="{Binding DurationText}" Grid.Column="2" Margin="4" VerticalAlignment="Center" Foreground="#CCCCCC" />
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+
+        </StackPanel>
 
         <GridSplitter Grid.Column="0" Grid.Row="2" Grid.RowSpan="2" Width="5" />
         <GridSplitter Grid.Row="2" Grid.Column="1" Panel.ZIndex="10" Style="{DynamicResource HorizontalGridSplitter}" VerticalAlignment="Bottom"  />


### PR DESCRIPTION
## A picture tells a thousand words
By default : 
![image](https://github.com/AxaFrance/webengine-dotnet/assets/10177061/e3d6a87c-fdc3-4618-a36d-5a67e5266876)

filter "Failed" :
![image](https://github.com/AxaFrance/webengine-dotnet/assets/10177061/0cdd5e45-c8b2-410e-8ad4-9369bfcb03d4)

Text filter : 
![image](https://github.com/AxaFrance/webengine-dotnet/assets/10177061/cc424647-2217-4c6a-be4f-380d0f995664)

## Summary
Adding 2 fields checked while loading testcases