### PR TITLE
fix: align search tb to left in reportviewer

### DIFF
--- a/src/AxaFrance.WebEngine.ReportViewer/MainWindow.xaml
+++ b/src/AxaFrance.WebEngine.ReportViewer/MainWindow.xaml
@@ -137,9 +137,8 @@
 
 
         <StackPanel Orientation="Vertical" VerticalAlignment="Top" Grid.Row="2" Grid.Column="0" Grid.RowSpan="2">
-
-            <StackPanel Orientation="Horizontal"  HorizontalAlignment="Right" VerticalAlignment="Top">
-                <Label Content="Filter" HorizontalAlignment="Left"   />
+            <StackPanel Orientation="Horizontal"  HorizontalAlignment="left" VerticalAlignment="Top">
+                <Label Content="Filter" HorizontalAlignment="Left" />
                 <TextBox x:Name="txFilter" HorizontalAlignment="Left" TextWrapping="Wrap" Text="" Height="25" Width="175" TextChanged="TxFilter_OnTextChanged" />
                 <CheckBox x:Name="cbFailed" Content="Failed"  Foreground="White" Checked="CbFailed_OnChecked" Unchecked="cbFailed_Unchecked"/>
             </StackPanel>


### PR DESCRIPTION
## A picture tells a thousand words
![image](https://github.com/AxaFrance/webengine-dotnet/assets/10177061/d88a2f80-0c7c-42c8-8ff7-679409abef52)

## Before this PR
When the with of the left panel increase, the search texbox goes to the right

## After this PR
When the with of the left panel increase, the search texbox stick to the left
