### PR TITLE
update nuspec

### DIFF
--- a/src/AxaFrance.WebEngine.ReportViewer/AxaFrance.WebEngine.ReportViewer.nuspec
+++ b/src/AxaFrance.WebEngine.ReportViewer/AxaFrance.WebEngine.ReportViewer.nuspec
@@ -10,35 +10,27 @@
     <dependencies>
       <group targetFramework=".NETFramework4.8">
         <dependency id="AxaFrance.WebEngine" version="{{version}}" exclude="Build,Analyzers" />
-        <dependency id="AvalonEdit" version="6.3.0.90" exclude="Build,Analyzers" />
+        <dependency id="AvalonEdit" version="6.3.1.120" exclude="Build,Analyzers" />
         <dependency id="Hummingbird.UI" version="1.2.2772.2" exclude="Build,Analyzers" />
         <dependency id="LiveChartsCore.SkiaSharpView.WPF" version="2.0.0-rc4.5" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Web.WebView2" version="1.0.2957.106" exclude="Build,Analyzers" />
-        <dependency id="SkiaSharp" version="3.116.1" exclude="Build,Analyzers" />
-      </group>
-      <group targetFramework="net6.0-windows7.0">
-        <dependency id="AxaFrance.WebEngine" version="{{version}}" exclude="Build,Analyzers" />
-        <dependency id="AvalonEdit" version="6.3.0.90" exclude="Build,Analyzers" />
-        <dependency id="Hummingbird.UI" version="1.2.2772.2" exclude="Build,Analyzers" />
-        <dependency id="LiveChartsCore.SkiaSharpView.WPF" version="2.0.0-rc4.5" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Web.WebView2" version="1.0.2957.106" exclude="Build,Analyzers" />
-        <dependency id="SkiaSharp" version="3.116.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Web.WebView2" version="1.0.3351.48" exclude="Build,Analyzers" />
+        <dependency id="SkiaSharp" version="3.119.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0-windows7.0">
         <dependency id="AxaFrance.WebEngine" version="{{version}}" exclude="Build,Analyzers" />
-        <dependency id="AvalonEdit" version="6.3.0.90" exclude="Build,Analyzers" />
+        <dependency id="AvalonEdit" version="6.3.1.120" exclude="Build,Analyzers" />
         <dependency id="Hummingbird.UI" version="1.2.2772.2" exclude="Build,Analyzers" />
         <dependency id="LiveChartsCore.SkiaSharpView.WPF" version="2.0.0-rc4.5" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Web.WebView2" version="1.0.2957.106" exclude="Build,Analyzers" />
-        <dependency id="SkiaSharp" version="3.116.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Web.WebView2" version="1.0.3351.48" exclude="Build,Analyzers" />
+        <dependency id="SkiaSharp" version="3.119.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net9.0-windows7.0">
         <dependency id="AxaFrance.WebEngine" version="{{version}}" exclude="Build,Analyzers" />
-        <dependency id="AvalonEdit" version="6.3.0.90" exclude="Build,Analyzers" />
+        <dependency id="AvalonEdit" version="6.3.1.120" exclude="Build,Analyzers" />
         <dependency id="Hummingbird.UI" version="1.2.2772.2" exclude="Build,Analyzers" />
         <dependency id="LiveChartsCore.SkiaSharpView.WPF" version="2.0.0-rc4.5" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Web.WebView2" version="1.0.2957.106" exclude="Build,Analyzers" />
-        <dependency id="SkiaSharp" version="3.116.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Web.WebView2" version="1.0.3351.48" exclude="Build,Analyzers" />
+        <dependency id="SkiaSharp" version="3.119.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
     <frameworkReferences>
@@ -64,7 +56,6 @@
     </frameworkAssemblies>
     <contentFiles>
       <files include="any/net48/*.config" buildAction="None" copyToOutput="true" />
-      <files include="any/net6.0-windows7.0/*.json" buildAction="None" copyToOutput="true" />
       <files include="any/net8.0-windows7.0/*.json" buildAction="None" copyToOutput="true" />
       <files include="any/net9.0-windows7.0/*.json" buildAction="None" copyToOutput="true" />
     </contentFiles>
@@ -73,11 +64,6 @@
     <!-- Include net48 -->
     <file src="net48\*.exe" target="lib\net48" />
     <file src="net48\*.config" target="contentFiles\any\net48" />
-
-    <!-- Include net6.0 -->
-    <file src="net6.0-windows\*.dll" target="lib\net6.0-windows7.0" />
-    <file src="net6.0-windows\*.exe" target="lib\net6.0-windows7.0" />
-    <file src="net6.0-windows\*.json" target="contentFiles\any\net6.0-windows7.0" />
 
     <!-- Include net8.0 -->
     <file src="net8.0-windows\*.dll" target="lib\net8.0-windows7.0" />

--- a/src/AxaFrance.WebEngine.Runner/axafrance.webengine.webrunner.nuspec
+++ b/src/AxaFrance.WebEngine.Runner/axafrance.webengine.webrunner.nuspec
@@ -8,31 +8,25 @@
     <description>WebRunner executable to run keyword driven automated tests.</description>
     <copyright>AXA France</copyright>
     <tags>AXA WebEngine Automation Framework</tags>
-    <repository type="git" url="https://github.com/AxaFrance/webengine-dotnet" commit="bed5761482312266078d19c5577cda20c060c2df" />
+    <repository type="git" url="https://github.com/AxaFrance/webengine-dotnet" />
     <dependencies>
       <group targetFramework=".NETFramework4.8">
         <dependency id="AxaFrance.WebEngine" version="{{version}}" exclude="Build,Analyzers" />
         <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="SkiaSharp" version="3.116.1" exclude="Build,Analyzers" />
-        <dependency id="System.Text.Json" version="9.0.1" exclude="Build,Analyzers" />
-      </group>
-      <group targetFramework="net6.0">
-        <dependency id="AxaFrance.WebEngine" version="{{version}}" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="SkiaSharp" version="3.116.1" exclude="Build,Analyzers" />
-        <dependency id="System.Text.Json" version="9.0.1" exclude="Build,Analyzers" />        
+        <dependency id="SkiaSharp" version="3.119.0" exclude="Build,Analyzers" />
+        <dependency id="System.Text.Json" version="9.0.7" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="AxaFrance.WebEngine" version="{{version}}" exclude="Build,Analyzers" />
         <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="SkiaSharp" version="3.116.1" exclude="Build,Analyzers" />
-        <dependency id="System.Text.Json" version="9.0.1" exclude="Build,Analyzers" />
+        <dependency id="SkiaSharp" version="3.119.0" exclude="Build,Analyzers" />
+        <dependency id="System.Text.Json" version="9.0.7" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net9.0">
         <dependency id="AxaFrance.WebEngine" version="{{version}}" exclude="Build,Analyzers" />
         <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="SkiaSharp" version="3.116.1" exclude="Build,Analyzers" />
-        <dependency id="System.Text.Json" version="9.0.1" exclude="Build,Analyzers" />
+        <dependency id="SkiaSharp" version="3.119.0" exclude="Build,Analyzers" />
+        <dependency id="System.Text.Json" version="9.0.7" exclude="Build,Analyzers" />
       </group>
     </dependencies>
     <frameworkAssemblies>
@@ -47,7 +41,6 @@
     </frameworkAssemblies>
     <contentFiles>
       <files include="any/net48/*.config" buildAction="None" copyToOutput="true" />
-      <files include="any/net6.0/*.json" buildAction="None" copyToOutput="true" />
       <files include="any/net8.0/*.json" buildAction="None" copyToOutput="true" />
       <files include="any/net9.0/*.json" buildAction="None" copyToOutput="true" />
     </contentFiles>
@@ -56,11 +49,6 @@
     <!-- Include net48 -->
     <file src="net48\*.exe" target="lib\net48" />
     <file src="net48\*.config" target="contentFiles\any\net48" />
-
-    <!-- Include net6.0 -->
-    <file src="net6.0\*.dll" target="lib\net6.0" />
-    <file src="net6.0\*.exe" target="lib\net6.0" />
-    <file src="net6.0\*.json" target="contentFiles\any\net6.0" />
 
     <!-- Include net8.0 -->
     <file src="net8.0\*.dll" target="lib\net8.0" />


### PR DESCRIPTION
This pull request makes several updates to the `.nuspec` files for `AxaFrance.WebEngine.ReportViewer` and `AxaFrance.WebEngine.Runner`. The changes include updating dependency versions, removing support for .NET 6.0, and cleaning up related file references.

### Dependency Updates:
* Updated `AvalonEdit` to version `6.3.1.120` in the `AxaFrance.WebEngine.ReportViewer` package.
* Updated `Microsoft.Web.WebView2` to version `1.0.3351.48` and `SkiaSharp` to version `3.119.0` in the `AxaFrance.WebEngine.ReportViewer` package.
* Updated `SkiaSharp` to version `3.119.0` and `System.Text.Json` to version `9.0.7` in the `AxaFrance.WebEngine.Runner` package.

### Removal of .NET 6.0 Support:
* Removed dependency groups for `.NET 6.0` in both `AxaFrance.WebEngine.ReportViewer` and `AxaFrance.WebEngine.Runner`. [[1]](diffhunk://#diff-5282ada29d11ce2d02acdbdfa2eaba68e854a43df640528f71e5953f744f418fL13-R33) [[2]](diffhunk://#diff-407700df4bf7afc261918045d15a1c9455bd01d5dae529f594435138e4237327L11-R29)
* Removed file references for `.NET 6.0` in the `contentFiles` and `lib` sections of both `.nuspec` files. [[1]](diffhunk://#diff-5282ada29d11ce2d02acdbdfa2eaba68e854a43df640528f71e5953f744f418fL67) [[2]](diffhunk://#diff-5282ada29d11ce2d02acdbdfa2eaba68e854a43df640528f71e5953f744f418fL77-L81) [[3]](diffhunk://#diff-407700df4bf7afc261918045d15a1c9455bd01d5dae529f594435138e4237327L50) [[4]](diffhunk://#diff-407700df4bf7afc261918045d15a1c9455bd01d5dae529f594435138e4237327L60-L64)

### Repository Metadata:
* Removed the `commit` attribute from the `repository` metadata in the `AxaFrance.WebEngine.Runner` package.