### PR TITLE
Update package versions and improve test reporting

### DIFF
--- a/src/AxaFrance.AxeExtended.Selenium/AxaFrance.AxeExtended.Selenium.csproj
+++ b/src/AxaFrance.AxeExtended.Selenium/AxaFrance.AxeExtended.Selenium.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Deque.AxeCore.Selenium" Version="4.10.1" />
-    <PackageReference Include="SkiaSharp" Version="3.119.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AxaFrance.WebEngine.Doc/AxaFrance.WebEngine.Doc.csproj
+++ b/src/AxaFrance.WebEngine.Doc/AxaFrance.WebEngine.Doc.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.119.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AxaFrance.WebEngine.MobileApp/AxaFrance.WebEngine.MobileApp.csproj
+++ b/src/AxaFrance.WebEngine.MobileApp/AxaFrance.WebEngine.MobileApp.csproj
@@ -21,9 +21,9 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="8.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.34.0" />
-    <PackageReference Include="SkiaSharp" Version="3.119.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.35.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AxaFrance.WebEngine.ReportViewer/AxaFrance.WebEngine.ReportViewer.csproj
+++ b/src/AxaFrance.WebEngine.ReportViewer/AxaFrance.WebEngine.ReportViewer.csproj
@@ -44,8 +44,8 @@
     <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
     <PackageReference Include="Hummingbird.UI" Version="1.2.2772.2" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.0-rc4.5" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3351.48" />
-    <PackageReference Include="SkiaSharp" Version="3.119.0" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3485.44" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AxaFrance.WebEngine.Runner/AxaFrance.WebEngine.Runner.csproj
+++ b/src/AxaFrance.WebEngine.Runner/AxaFrance.WebEngine.Runner.csproj
@@ -41,9 +41,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="SkiaSharp" Version="3.119.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/AxaFrance.WebEngine.Web/AxaFrance.WebEngine.Web.csproj
+++ b/src/AxaFrance.WebEngine.Web/AxaFrance.WebEngine.Web.csproj
@@ -20,11 +20,11 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="8.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Selenium.Support" Version="4.34.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.34.0" />
-    <PackageReference Include="SkiaSharp" Version="3.119.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Selenium.Support" Version="4.35.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.35.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
     <PackageReference Include="WebDriverManager" Version="2.17.6" />
   </ItemGroup>
 

--- a/src/AxaFrance.WebEngine/AxaFrance.WebEngine.csproj
+++ b/src/AxaFrance.WebEngine/AxaFrance.WebEngine.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">

--- a/src/Samples.DataDriven/Samples.DataDriven.csproj
+++ b/src/Samples.DataDriven/Samples.DataDriven.csproj
@@ -44,8 +44,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.119.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples.Gherkin/Samples.Gherkin.csproj
+++ b/src/Samples.Gherkin/Samples.Gherkin.csproj
@@ -8,12 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="SkiaSharp" Version="3.119.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
     <PackageReference Include="SpecFlow.Plus.LivingDocPlugin" Version="3.9.57" />
     <PackageReference Include="SpecFlow.NUnit" Version="3.9.74" />
-    <PackageReference Include="nunit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="FluentAssertions" Version="8.5.0" />
+    <PackageReference Include="nunit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+    <PackageReference Include="FluentAssertions" Version="8.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples.KeywordDriven/Samples.KeywordDriven.csproj
+++ b/src/Samples.KeywordDriven/Samples.KeywordDriven.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.119.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples.LinearScripting/Samples.LinearScripting.csproj
+++ b/src/Samples.LinearScripting/Samples.LinearScripting.csproj
@@ -10,13 +10,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SkiaSharp" Version="3.119.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples.LinearScripting/UnitTest1.cs
+++ b/src/Samples.LinearScripting/UnitTest1.cs
@@ -49,6 +49,7 @@ namespace Samples.LinearScripting
                 UnitTestOutcome.Error => Result.CriticalError,
                 _ => Result.None
             };
+
             testCaseReport.EndTime = DateTime.Now;
             //Close the driver (and browser) after each test case.
             driver?.Close();
@@ -60,7 +61,7 @@ namespace Samples.LinearScripting
         {
             //After all test cases, we will save the test suite report.
             testSuiteReport!.EndTime = DateTime.Now;
-            var reportPath = testSuiteReport.SaveAs("TestReport", "MyTestReport", false);
+            var reportPath = testSuiteReport.SaveAs("TestReport", "TEST-MyTestReport", false);
 
             //you can check the test report in folder bin\Debug\net8.0\TestReport of your test project.
             DebugLogger.WriteLine($"Test Suite Report saved at: {reportPath}");
@@ -73,21 +74,39 @@ namespace Samples.LinearScripting
         public void SelectDrinkTest()
         {
             driver!.Navigate().GoToUrl("https://axafrance.github.io/webengine-dotnet/demo/Step1.html");
-            
+
 
             //during the test execution, we can add some action reports to the test case report.
-            testCaseReport.ActionReports.Add(new ActionReport
+            var step1Report = new ActionReport
             {
                 Name = "Navigate to Step 1 page",
                 Result = Result.Passed,
                 Log = "Navigated to Step 1 page successfully."
-            });
+            };
+
+            testCaseReport.ActionReports.Add(step1Report);
 
             //Create a page model for the Drink Selection page.
             DrinkSelectionPageModel page = new DrinkSelectionPageModel(driver);
             page.SelectLanguage.SelectByValue("fr");
             page.RadioChooseToBuy.CheckByValue("Coffee");
+            var screenshot = driver!.GetScreenshot();
             page.NextButton.Click();
+
+            var actionReport = new ActionReport
+            {
+                Name = "Select language and drink",
+                Result = Result.Passed,
+                Log = "Selected French language and Coffee drink.",
+            };
+            actionReport.Screenshots.Add(new ScreenshotReport
+            {
+                Name = "DrinkSelectionPageScreenshot",
+                Data = screenshot.AsByteArray,
+            });
+            step1Report.SubActionReports.Add(actionReport);
+
+
 
             testCaseReport.ActionReports.Add(new ActionReport
             {

--- a/src/WebEngine.Test/WebEngine.Test.csproj
+++ b/src/WebEngine.Test/WebEngine.Test.csproj
@@ -28,13 +28,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SkiaSharp" Version="3.119.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Updated `SkiaSharp` to version `3.119.1` across multiple projects.
- Updated `Newtonsoft.Json` to version `13.0.4` in several files.
- Updated `Selenium.WebDriver` and `Selenium.Support` to version `4.35.0`.
- Updated `System.Text.Json` to version `9.0.9` in relevant projects.
- Updated `MSTest.TestAdapter` and `MSTest.TestFramework` to version `3.10.4`.
- Modified report naming convention in `ClassTearDown` for clarity.
- Enhanced action reporting in `SelectDrinkTest` for better tracking.
- General code cleanup and organization for improved maintainability.

## A picture tells a thousand words

## Before this PR

## After this PR